### PR TITLE
28- Delete Burn

### DIFF
--- a/src/components/postItem/postItem.jsx
+++ b/src/components/postItem/postItem.jsx
@@ -22,42 +22,12 @@ function PostItem({ id, comment, username }) {
   });
 
   const handleDelete = () => {
-    if (window.confirm('Delete this entry?')) {
-      deleteBurn({ id: id });
+    if (user !== undefined && user.user_metadata.username === username) {
+      if (window.confirm('Delete this entry?')) {
+        deleteBurn({ id: id });
+      }
     }
   };
-
-  // const handleDelete2 = async (event) => {
-  //   const result = confirm('Delete this entry?');
-  //   if (result) {
-  //     // in case we need to track if something is loading for UX
-  //     // setLoading(true);
-
-  //     try {
-  //       let res = await fetch('/getBurns', {
-  //         method: 'DELETE',
-  //         headers: {
-  //           'Content-Type': 'application/json',
-  //         },
-  //         body: JSON.stringify({
-  //           id: id,
-  //         }),
-  //       });
-
-  //       // 204 status "No Content" for delete requests
-  //       if (res.status === 204) {
-  //         setMessage('Error occurred in the delete request');
-  //       }
-  //     } catch (err) {
-  //       console.log(err);
-  //       setMessage(
-  //         "Fetch didn't happen - Error occurred fetching data in delete request"
-  //       );
-  //     }
-
-  //     setLoading(false); // Set loading back to false after the API call is completed
-  //   }
-  // };
 
   // update function
   // modal shows if logged in user matches user
@@ -66,9 +36,10 @@ function PostItem({ id, comment, username }) {
 
     const username = event.target.parentElement.dataset.user;
 
-    if (user.user_metadata.username === username) {
+    if (user !== undefined && user.user_metadata.username === username) {
       setModalState(!modalState);
     }
+    setLoading(false);
   };
 
   return (

--- a/src/components/postItem/postItem.jsx
+++ b/src/components/postItem/postItem.jsx
@@ -12,19 +12,14 @@ function PostItem({ id, comment, username }) {
 
   const { user } = useAuth();
 
-  const { mutate: deleteBurn, isLoading } = useDeleteBurn({
-    onSuccess: () => {
-      setMessage('Entry successfully deleted');
-    },
-    onError: (error) => {
-      setMessage(`Error deleting entry: ${error.message}`);
-    },
-  });
+  const { mutate } = useDeleteBurn();
 
-  const handleDelete = () => {
+  const handleDelete = (event) => {
+    event.preventDefault();
+
     if (user !== undefined && user.user_metadata.username === username) {
       if (window.confirm('Delete this entry?')) {
-        deleteBurn({ id: id });
+        mutate({ id: id });
       }
     }
   };

--- a/src/hooks/fetchMutations.jsx
+++ b/src/hooks/fetchMutations.jsx
@@ -58,14 +58,17 @@ export const useUpdateBurn = () => {
 };
 
 // delete a burn - DELETE request
-export const deleteBurn = async (id) => {
-  console.log('ID', id);
-  const res = await fetch('/getBurns', {
+export const deleteBurn = async (burn) => {
+  const { data } = await supabase.auth.getSession();
+
+  console.log('DELETE BURN', burn.id);
+  const res = await fetch(`getBurns/${burn.id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${data.session.access_token}`,
     },
-    body: JSON.stringify(id),
+    body: JSON.stringify(burn),
   });
   return res.json();
 };

--- a/src/hooks/fetchMutations.jsx
+++ b/src/hooks/fetchMutations.jsx
@@ -30,7 +30,6 @@ export const useAddBurn = () => {
 };
 
 // update a burn - PATCH request
-// need an id?
 export const updateBurn = async (burn) => {
   const { data } = await supabase.auth.getSession();
 
@@ -61,16 +60,15 @@ export const useUpdateBurn = () => {
 export const deleteBurn = async (burn) => {
   const { data } = await supabase.auth.getSession();
 
-  console.log('DELETE BURN', burn.id);
   const res = await fetch(`getBurns/${burn.id}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${data.session.access_token}`,
     },
-    body: JSON.stringify(burn),
   });
-  return res.json();
+
+  return;
 };
 
 export const useDeleteBurn = () => {
@@ -81,7 +79,6 @@ export const useDeleteBurn = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['burns'] });
-      console.log('Girl on girl crime deleted');
     },
   });
 };

--- a/src/server/controllers/burnController.js
+++ b/src/server/controllers/burnController.js
@@ -135,8 +135,9 @@ burnController.updateBurn = async (req, res, next) => {
 
 // delete a burn from database
 burnController.deleteBurn = async (req, res, next) => {
-  const id = req.body.id;
-  console.log(id);
+  console.log('IN DELETE BURN', id);
+  // const id = req.body.id;
+  const { id } = req.params;
 
   try {
     const { data, error } = await supabase
@@ -148,7 +149,7 @@ burnController.deleteBurn = async (req, res, next) => {
     if (error) throw error;
 
     res.locals.result = data;
-    res.sendStatus(204);
+
     return next();
   } catch (err) {
     return next({

--- a/src/server/controllers/burnController.js
+++ b/src/server/controllers/burnController.js
@@ -135,20 +135,36 @@ burnController.updateBurn = async (req, res, next) => {
 
 // delete a burn from database
 burnController.deleteBurn = async (req, res, next) => {
-  console.log('IN DELETE BURN', id);
-  // const id = req.body.id;
+  const authHeader = req.headers.authorization;
+
+  // if no auth headers, return status 401
+  if (!authHeader) {
+    console.log('we are returning bc no headers :(');
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const token = authHeader.split(' ')[1];
+
   const { id } = req.params;
 
+  if (!id) {
+    console.log('Missing required parameters');
+    return res.status(400).json({ message: 'Invalid request data' });
+  }
+
   try {
-    const { data, error } = await supabase
+    const { error } = await supabaseAuth(token)
       .from('burn_book')
       .delete()
       .eq('id', id)
-      .single();
+      .select();
 
-    if (error) throw error;
+    if (error) {
+      console.log('Supabase error:', error);
+      return res.status(500).json({ message: 'Database operation failed' });
+    }
 
-    res.locals.result = data;
+    // don't need a response body for delete w/ status 204
 
     return next();
   } catch (err) {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -65,9 +65,14 @@ app.get('/getBurns/:id', burnController.getBurnById, (req, res) =>
 );
 
 // delete an entry
-app.delete('/getBurns', burnController.deleteBurn, (req, res) => {
-  res.status(204).json(res.locals.result);
-});
+app.delete(
+  '/getBurns/:id',
+  supabaseAuthMiddleware.middleware,
+  burnController.deleteBurn,
+  (req, res) => {
+    res.status(204).json(res.locals.result);
+  }
+);
 
 // update an entry
 app.patch(


### PR DESCRIPTION
## Purpose

This PR fine tunes the TanStack Query implementation for the ability to delete an entry in the Burn Book, and handles necessary errors for the update request.

This PR sets up TanStack Query mutations in ```fetchMutation.jsx``` and handles "delete" so that when a user deletes one of their entries in the Burn Book, it is automatically seen in the feed of posts. Users are only able to delete their own entries.

It also fixes the runtime error of user_metadata in the event someone is not logged in from the function that prevents buttons from functioning if the author of the entry does not match the logged in user.

Closes #28 